### PR TITLE
Fix README names

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Features
 
 - Setup only takes a few minutes [single config file](./src/data/resume-data.tsx)
-- Built using Next.js 14, React, Typescript, Shadcn/ui, TailwindCss
+- Built using Next.js 14, React, TypeScript, shadcn/ui, TailwindCss
 - Auto generated Layout
 - Responsive for different devices
 - Optimized for Next.js and Vercel


### PR DESCRIPTION
## Summary
- fix references to `TypeScript` and `shadcn/ui`

## Testing
- `yarn lint` *(fails: tunneling socket could not be established)*

------
https://chatgpt.com/codex/tasks/task_e_68484af997948320b356bd0793862566